### PR TITLE
메인화면 + 리뷰 완성

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -1,8 +1,3 @@
-/* =============================
-   App.css  (페이지 레이아웃 전용)
-   ============================= */
-
-/* 디자인 토큰 (피그마 값으로 교체 가능) */
 :root{
   --brand-500:#0C2E86;
   --ink-900:#0E1A2B;
@@ -11,7 +6,7 @@
   --line-200:#E6ECF7;
   --bg-50:#F7F9FE;
 
-  --container: 885px;   /* 피그마 타이틀+탭 그룹 기준폭 */
+  --container: 885px;
   --page-pad: 16px;
 
   --radius-8: 8px;
@@ -20,11 +15,10 @@
 
 *{ box-sizing:border-box; }
 
-/* ▼ 스크롤바 공간을 항상 예약해 페이지 좌우 흔들림 방지 */
 html{
   scrollbar-gutter: stable both-edges;
 }
-/* 구형 브라우저 폴백 */
+
 @supports not (scrollbar-gutter: stable){
   html{ overflow-y: scroll; }
 }
@@ -38,7 +32,6 @@ body{
   letter-spacing:-0.2px;
 }
 
-/* 접근성 유틸 */
 .sr-only{
   position:absolute !important;
   width:1px; height:1px;
@@ -46,14 +39,12 @@ body{
   overflow:hidden; clip:rect(0,0,0,0); white-space:nowrap; border:0;
 }
 
-/* 페이지 컨테이너: 항상 중앙 + 작은 화면에서 안전하게 줄어들도록 */
 .app__container{
   width: clamp(320px, 100vw - calc(var(--page-pad) * 2), var(--container));
   margin-inline: auto;
   padding: 12px var(--page-pad) 56px;
 }
 
-/* 섹션 공통 */
 .section{ margin-top: 12px; padding: 12px;}
 .section__head{
   display:flex;
@@ -69,7 +60,6 @@ body{
   font-size:19px;
 }
 
-/* 컨트롤(셀렉트) */
 .section__head--controls .controls{
   display:flex; gap:8px; align-items:center;
 }
@@ -97,31 +87,26 @@ body{
 }
 .pagination__btn,
 .pagination__num{
-  /* 폭/높이 고정 + 등폭 숫자 → 레이아웃 흔들림 방지 */
   display:inline-flex; align-items:center; justify-content:center;
   min-width:32px; height:32px;
   padding:0 8px;
   border:none; background:transparent;
   box-sizing:border-box;
   font-weight:600; font-size:12px;
-  font-variant-numeric: tabular-nums; /* 숫자 등폭 */
+  font-variant-numeric: tabular-nums;
   color:var(--ink-700);
   cursor:pointer;
-  /* 활성 상태에서 border가 생겨도 전체 폭이 변하지 않도록 기본 투명 보더 지정 */
   border-bottom:2px solid transparent;
 }
 .pagination__btn[disabled]{ opacity:.45; cursor:default; }
-/* 활성 효과: border-bottom 색만 바꿔서 레이아웃 불변 */
 .pagination__num.is-active{
   color:var(--brand-500);
   border-bottom-color: var(--brand-500);
 }
 
-/* 카드 그리드 */
 .grid{ display:grid; gap:16px; }
 .grid--3{ grid-template-columns: repeat(3, minmax(0, 1fr)); }
 
-/* 이미지 로딩 시 높이 요동 방지: 자리 먼저 확보 */
 .partnership-card img,
 .card__image{
   width:100%;
@@ -139,7 +124,6 @@ body{
   .section__head--controls{ flex-wrap: wrap; gap: 6px; }
 }
 
-/* ===== MultiSelect (드롭다운형 멀티) ===== */
 .ms{ position: relative; display: inline-block; min-width: 140px; }
 .ms__button{
   width: 100%;

--- a/src/App.css
+++ b/src/App.css
@@ -48,7 +48,6 @@ body{
 
 /* 페이지 컨테이너: 항상 중앙 + 작은 화면에서 안전하게 줄어들도록 */
 .app__container{
-  /* 320px ~ 881px 사이에서 반응, 좌우 패딩 유지, 큰 화면엔 881px 중앙 정렬 */
   width: clamp(320px, 100vw - calc(var(--page-pad) * 2), var(--container));
   margin-inline: auto;
   padding: 12px var(--page-pad) 56px;

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -14,6 +14,8 @@ import "./App.css";
      /partnership-info?organization=a,b,c&category=x,y&type=m,n&sort={정렬}&page={페이지}
    ========================================================= */
 
+const API_BASE = import.meta.env.VITE_API_BASE ?? "";
+
 // fallback용 임시 썸네일 (DTO에 imageUrl 없을 때만 사용)
 const random_img = (id) => `https://picsum.photos/400/300?random=${id}`;
 
@@ -22,13 +24,20 @@ const ORGANIZATIONS = ["전체", "총학", "총동", "단과대", "학과", "기
 const CATEGORIES    = ["전체", "음식", "카페", "생활", "문화"];
 const TYPES         = ["전체", "할인", "서비스"];
 
+// const SORTS = [
+//   { key: "idAsc", label: "등록순" },
+//   { key: "popular", label: "조회수 높은 순" },
+//   { key: "discountDesc", label: "할인율 높은 순" },
+//   { key: "discountAsc", label: "할인율 낮은 순" },
+//   { key: "deadlineAsc", label: "기한 빠른 순" },
+//   { key: "deadlineDesc", label: "기한 느린 순" },
+// ];
+
 const SORTS = [
-  { key: "idAsc", label: "등록순" },
-  { key: "popular", label: "조회수 높은 순" },
-  { key: "discountDesc", label: "할인율 높은 순" },
-  { key: "discountAsc", label: "할인율 낮은 순" },
-  { key: "deadlineAsc", label: "기한 빠른 순" },
-  { key: "deadlineDesc", label: "기한 느린 순" },
+  { key: "views", label: "조회수 높은 순" },
+  { key: "discountRate", label: "할인율 높은 순" },
+  { key: "saleStartDate", label: "시작일 빠른 순" },
+  { key: "saleEndDate", label: "종료일 빠른 순" },
 ];
 
 /* =========================================================
@@ -37,13 +46,20 @@ const SORTS = [
    ========================================================= */
 const toCard = (dto, idx = 0, offset = 0) => {
   const id = dto.id ?? offset + idx + 1;
+
+  const imgUrl = dto.partnershipImageUrl
+    ? `${API_BASE}${dto.partnershipImageUrl}`
+    : random_img(id);
+
+  console.log("[toCard IMG]", dto.partnershipImageUrl, "->", imgUrl);
+
   return {
     id,
     title: dto.content ?? "",
     merchant: dto.storeName ?? "",
     tags: [dto.organization, dto.type].filter(Boolean),
     category: dto.category ?? "",
-    img: dto.partnershipImageUrl || random_img(id),
+    img: imgUrl,
     hot: false,
   };
 };
@@ -264,7 +280,7 @@ function HomePage() {
   const [top3, setTop3] = useState([]);
   const [allList, setAll] = useState([]);
 
-  const API_BASE = import.meta.env.VITE_API_BASE ?? "";
+  // const API_BASE = import.meta.env.VITE_API_BASE ?? "";
   const USE_MOCK = false;
 
   // 서버 호출

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -108,17 +108,30 @@ function MultiSelect({ options, value, onChange, label, ariaLabel }) {
       onChange(["전체"]);
       return;
     }
+
     let next = Array.isArray(value) ? [...value] : [];
     // 전체가 포함돼 있으면 제거
     next = next.filter((v) => v !== "전체");
+
     if (next.includes(opt)) {
       next = next.filter((v) => v !== opt);
     } else {
       next.push(opt);
     }
-    if (next.length === 0) next = ["전체"];
+
+    if (next.length === 0) {
+      next = ["전체"];
+    } else {
+      // 🔹 전체를 제외한 나머지 옵션을 전부 선택했을 때 → 전체로 통일
+      const withoutAll = options.filter((o) => o !== "전체");
+      if (withoutAll.every((o) => next.includes(o))) {
+        next = ["전체"];
+      }
+    }
+
     onChange(next);
   };
+
 
   return (
     <div className="ms">

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -19,19 +19,10 @@ const API_BASE = import.meta.env.VITE_API_BASE ?? "";
 // fallback용 임시 썸네일 (DTO에 imageUrl 없을 때만 사용)
 const random_img = (id) => `https://picsum.photos/400/300?random=${id}`;
 
-// ▼ 드롭다운 옵션
+// 드롭다운 옵션
 const ORGANIZATIONS = ["전체", "총학", "총동", "단과대", "학과", "기타"];
 const CATEGORIES    = ["전체", "음식", "카페", "생활", "문화"];
 const TYPES         = ["전체", "할인", "서비스"];
-
-// const SORTS = [
-//   { key: "idAsc", label: "등록순" },
-//   { key: "popular", label: "조회수 높은 순" },
-//   { key: "discountDesc", label: "할인율 높은 순" },
-//   { key: "discountAsc", label: "할인율 낮은 순" },
-//   { key: "deadlineAsc", label: "기한 빠른 순" },
-//   { key: "deadlineDesc", label: "기한 느린 순" },
-// ];
 
 const SORTS = [
   { key: "views", label: "조회수 높은 순" },
@@ -44,19 +35,19 @@ const SORTS = [
    DTO -> 카드 props 매핑
    - 서버 DTO: { id?, content, storeName, organization, category, type, imageUrl? }
    ========================================================= */
+
 const toCard = (dto, idx = 0, offset = 0) => {
-  // partnershipId가 있으면 최우선, 없으면 dto.id, 그래도 없으면 fallback
   const id = dto.partnershipId
 
   const imgUrl = dto.partnershipImageUrl
     ? `${API_BASE}${dto.partnershipImageUrl}`
     : random_img(id);
 
-  // (선택) 디버깅: 어떤 id가 매핑됐는지 확인하고 싶다면 주석 해제
+  // 어떤 id가 매핑됐는지 확인
   console.log("[toCard] dto.partnershipId =", dto.partnershipId, "dto.id =", dto.id, "=> id =", id);
 
   return {
-    id, // ← 라우팅에 쓰이는 값 (to={`/info/${item.id}`})
+    id, // 라우팅에 쓰이는 값 (to={`/info/${item.id}`})
     title: dto.content ?? "",
     merchant: dto.storeName ?? "",
     tags: [dto.organization, dto.type].filter(Boolean),

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -18,7 +18,7 @@ import "./App.css";
 const random_img = (id) => `https://picsum.photos/400/300?random=${id}`;
 
 // ▼ 드롭다운 옵션
-const ORGANIZATIONS = ["전체", "총학생회", "총동연", "단과대", "학과", "기타"];
+const ORGANIZATIONS = ["전체", "총학", "총동", "단과대", "학과", "기타"];
 const CATEGORIES    = ["전체", "음식", "카페", "생활", "문화"];
 const TYPES         = ["전체", "할인", "서비스"];
 
@@ -43,7 +43,7 @@ const toCard = (dto, idx = 0, offset = 0) => {
     merchant: dto.storeName ?? "",
     tags: [dto.organization, dto.type].filter(Boolean),
     category: dto.category ?? "",
-    img: dto.url || dto.imageUrl || random_img(id),
+    img: dto.partnershipImageUrl || random_img(id),
     hot: false,
   };
 };
@@ -318,7 +318,7 @@ function HomePage() {
             organization: x?.organization,
             category: x?.category,
             type: x?.type,
-            imageUrl: x?.imageUrl,
+            partnershipImageUrl: x?.partnershipImageUrl,
           });
           console.table(listRaw.slice(0, 5).map(pick));
           console.groupEnd();

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -45,16 +45,18 @@ const SORTS = [
    - 서버 DTO: { id?, content, storeName, organization, category, type, imageUrl? }
    ========================================================= */
 const toCard = (dto, idx = 0, offset = 0) => {
-  const id = dto.id ?? offset + idx + 1;
+  // partnershipId가 있으면 최우선, 없으면 dto.id, 그래도 없으면 fallback
+  const id = dto.partnershipId
 
   const imgUrl = dto.partnershipImageUrl
     ? `${API_BASE}${dto.partnershipImageUrl}`
     : random_img(id);
 
-  console.log("[toCard IMG]", dto.partnershipImageUrl, "->", imgUrl);
+  // (선택) 디버깅: 어떤 id가 매핑됐는지 확인하고 싶다면 주석 해제
+  console.log("[toCard] dto.partnershipId =", dto.partnershipId, "dto.id =", dto.id, "=> id =", id);
 
   return {
-    id,
+    id, // ← 라우팅에 쓰이는 값 (to={`/info/${item.id}`})
     title: dto.content ?? "",
     merchant: dto.storeName ?? "",
     tags: [dto.organization, dto.type].filter(Boolean),
@@ -63,6 +65,7 @@ const toCard = (dto, idx = 0, offset = 0) => {
     hot: false,
   };
 };
+
 
 // "전체" → 빈 문자열, 배열 선택값은 콤마로 합치기
 const encodeMultiParam = (arr) => {
@@ -342,6 +345,7 @@ function HomePage() {
           });
           console.log("[ALL] pageAmount =", pageAmount);
           const pick = (x) => ({
+            partnershipId: x?.partnershipId,
             content: x?.content,
             storeName: x?.storeName,
             organization: x?.organization,

--- a/src/components/PartnershipCard.css
+++ b/src/components/PartnershipCard.css
@@ -1,6 +1,6 @@
 .partnership-card{
   width: 100%;
-  min-width: 0;                  /* 그리드 계산에 영향 안 주도록 */
+  min-width: 0;
   border: 1px solid #0C2E86;
   border-radius: var(--radius-12);
   overflow: hidden;

--- a/src/components/PartnershipCard.jsx
+++ b/src/components/PartnershipCard.jsx
@@ -14,6 +14,7 @@ import "./PartnershipCard.css";
  *   hot: boolean
  * }
  */
+
 export default function PartnershipCard({ item, to, onClick }) {
   if (!item) return null;
 

--- a/src/pages/InfoDetail/OceanWorld.jsx
+++ b/src/pages/InfoDetail/OceanWorld.jsx
@@ -1,5 +1,5 @@
 import React, { useState, useEffect } from "react";
-import { useParams } from "react-router-dom"; // ✅ URL 파라미터 읽기
+import { useParams } from "react-router-dom";
 import "../../styles/InfoDetail/OceanWorld.css";
 import TopBanner from "../../components/TopBanner";
 import ReviewModal from "../ReviewWrite/ReviewModal";
@@ -15,7 +15,7 @@ function toAbsUrl(path) {
 }
 
 function OceanWorld() {
-    const { partnershipId } = useParams(); // ✅ 주소에서 partnershipID 추출
+    const { partnershipId } = useParams();
     const [activeTab, setActiveTab] = useState("info");
     const [showModal, setShowModal] = useState(false);
 
@@ -206,7 +206,7 @@ function OceanWorld() {
             {/* 리뷰 모달 */}
             {showModal && (
                 <ReviewModal
-                    partnershipId={partnershipId} // ✅ props로 전달
+                    partnershipId={partnershipId}
                     onClose={() => setShowModal(false)}
                 />
             )}

--- a/src/pages/InfoDetail/OceanWorld.jsx
+++ b/src/pages/InfoDetail/OceanWorld.jsx
@@ -4,6 +4,16 @@ import "../../styles/InfoDetail/OceanWorld.css";
 import TopBanner from "../../components/TopBanner";
 import ReviewModal from "../ReviewWrite/ReviewModal";
 
+const API_BASE = import.meta.env.VITE_API_BASE ?? "";
+
+// 서버에서 내려주는 "/files/..." 경로를 절대경로로 바꿔주는 함수
+function toAbsUrl(path) {
+    if (!path) return "";
+    if (path.startsWith("http://") || path.startsWith("https://")) return path;
+    const slash = path.startsWith("/") ? "" : "/";
+    return `${API_BASE}${slash}${path}`;
+}
+
 function OceanWorld() {
     const { partnershipId } = useParams(); // ✅ 주소에서 partnershipID 추출
     const [activeTab, setActiveTab] = useState("info");
@@ -11,29 +21,56 @@ function OceanWorld() {
 
     // --- 연동용 상태 ---
     const [infoData, setInfoData] = useState(null);
-    const [reviewData, setReviewData] = useState([]);
+    const [reviewData, setReviewData] = useState({ partnershipImageUrl: "", summary: "", items: [] });
+    const [loadingReview, setLoadingReview] = useState(false);
+    const [reviewError, setReviewError] = useState("");
+
+    // 페이지네이션 상태
+    const [reviewPage, setReviewPage] = useState(1);
+    const REVIEWS_PER_PAGE = 7; // 한 페이지에 표시할 리뷰 개수
 
     useEffect(() => {
         if (!partnershipId) return;
 
-        fetch(
-            `${
-                import.meta.env.VITE_API_BASE
-            }/partnership-info/detail/${partnershipId}/inform`
-        )
+        fetch(`${API_BASE}/partnership-info/detail/${partnershipId}/inform`)
             .then((res) => res.json())
             .then((data) => setInfoData(data))
             .catch(() => console.error("정보 불러오기 실패"));
 
-        fetch(
-            `${
-                import.meta.env.VITE_API_BASE
-            }/partnership-info/detail/${partnershipId}/review`
-        )
+        setLoadingReview(true);
+        setReviewError("");
+        fetch(`${API_BASE}/partnership-info/detail/${partnershipId}/review`)
             .then((res) => res.json())
-            .then((data) => setReviewData(data))
-            .catch(() => console.error("리뷰 불러오기 실패"));
+            .then((data) => {
+                const items = Array.isArray(data.items)
+                    ? data.items.map((it) => ({
+                          text: it?.text ?? "",
+                          photoUrl: Array.isArray(it?.photoUrl) ? it.photoUrl : [],
+                      }))
+                    : [];
+                setReviewData({
+                    partnershipImageUrl: data.partnershipImageUrl || "",
+                    summary: data.summary || "",
+                    items,
+                });
+                setReviewPage(1); // 새 데이터 오면 첫 페이지로 초기화
+            })
+            .catch(() => {
+                console.error("리뷰 불러오기 실패");
+                setReviewError("리뷰 정보를 불러오지 못했습니다.");
+            })
+            .finally(() => setLoadingReview(false));
     }, [partnershipId]);
+
+    const mainImgSrc = toAbsUrl(reviewData.partnershipImageUrl) || "/oceanworld.png";
+
+    // 페이지네이션 계산
+    const totalReviews = reviewData.items?.length || 0;
+    const totalReviewPages = Math.max(1, Math.ceil(totalReviews / REVIEWS_PER_PAGE));
+    const pagedReviews = reviewData.items.slice(
+        (reviewPage - 1) * REVIEWS_PER_PAGE,
+        reviewPage * REVIEWS_PER_PAGE
+    );
 
     return (
         <div className="oceanworld-container">
@@ -42,31 +79,23 @@ function OceanWorld() {
 
             {/* 메인 카드 */}
             <div className="detail-card">
-                <h2 className="store-name">오션월드</h2>
+                <h2 className="store-name">{infoData?.name || "제휴 매장"}</h2>
 
                 {/* 이미지 영역 */}
                 <div className="image-wrapper">
-                    <img
-                        src="/oceanworld.png"
-                        alt="오션월드"
-                        className="main-image"
-                    />
+                    <img src={mainImgSrc} alt={infoData?.name || "제휴 이미지"} className="main-image" />
                 </div>
 
                 {/* 탭 버튼 */}
                 <div className="tab-buttons">
                     <button
-                        className={`tab-btn ${
-                            activeTab === "info" ? "active" : ""
-                        }`}
+                        className={`tab-btn ${activeTab === "info" ? "active" : ""}`}
                         onClick={() => setActiveTab("info")}
                     >
                         정보
                     </button>
                     <button
-                        className={`tab-btn ${
-                            activeTab === "review" ? "active" : ""
-                        }`}
+                        className={`tab-btn ${activeTab === "review" ? "active" : ""}`}
                         onClick={() => setActiveTab("review")}
                     >
                         리뷰
@@ -86,14 +115,10 @@ function OceanWorld() {
                                         <strong>혜택:</strong> {infoData.type}
                                     </p>
                                     <p>
-                                        <strong>판매 기간:</strong>{" "}
-                                        {infoData.saleStartDate} ~{" "}
-                                        {infoData.saleEndDate}
+                                        <strong>판매 기간:</strong> {infoData.saleStartDate} ~ {infoData.saleEndDate}
                                     </p>
                                     <p>
-                                        <strong>사용 기간:</strong>{" "}
-                                        {infoData.useStartDate} ~{" "}
-                                        {infoData.useEndDate}
+                                        <strong>사용 기간:</strong> {infoData.useStartDate} ~ {infoData.useEndDate}
                                     </p>
                                     <p>
                                         <strong>비고:</strong> {infoData.note}
@@ -104,28 +129,72 @@ function OceanWorld() {
                             )}
                         </div>
                     )}
+
                     {activeTab === "review" && (
                         <div className="review-section">
+                            {/* AI 요약 */}
+                            <div className="review-summary-block">
+                                <div className="review-summary-head">
+                                    <span className="review-summary-emoji" aria-hidden>🤖</span>
+                                    <span className="review-summary-label">AI 요약</span>
+                                </div>
+                                <div className="review-summary-card">{reviewData.summary || "리뷰 요약이 없습니다."}</div>
+                            </div>
+
+                            {/* 리뷰 작성 버튼 */}
                             <button
                                 className="review-write-btn"
                                 onClick={() => setShowModal(true)}
                             >
                                 리뷰 작성
                             </button>
-                            {reviewData.length > 0 ? (
-                                reviewData.map((review, idx) => (
-                                    <div key={idx} className="review-item">
-                                        {review.photoUrl?.map((url, i) => (
-                                            <img
-                                                key={i}
-                                                src={url}
-                                                alt={`review-${i}`}
-                                                className="review-photo"
-                                            />
-                                        ))}
-                                        <p>{review.text}</p>
-                                    </div>
-                                ))
+
+                            {/* 리뷰 리스트 제목 */}
+                            <h3 className="review-list-title">리뷰 ({reviewData.items?.length || 0})</h3>
+
+                            {loadingReview ? (
+                                <p className="muted">불러오는 중...</p>
+                            ) : reviewError ? (
+                                <p className="error">{reviewError}</p>
+                            ) : pagedReviews && pagedReviews.length > 0 ? (
+                                <>
+                                    {pagedReviews.map((review, idx) => (
+                                        <div key={idx} className="review-item">
+                                            {review.photoUrl?.map((url, i) => (
+                                                <img
+                                                    key={i}
+                                                    src={toAbsUrl(url)}
+                                                    alt={`review-${i}`}
+                                                    className="review-photo"
+                                                    loading="lazy"
+                                                />
+                                            ))}
+                                            <p className="review-text">{review.text}</p>
+                                        </div>
+                                    ))}
+                                    {/* 페이지네이션 */}
+                                    {totalReviewPages > 1 && (
+                                        <div className="review-pagination" role="navigation" aria-label="리뷰 페이지네이션">
+                                            <button
+                                                type="button"
+                                                className="page-btn"
+                                                onClick={() => setReviewPage(p => Math.max(1, p - 1))}
+                                                disabled={reviewPage === 1}
+                                            >
+                                                이전
+                                            </button>
+                                            <span className="page-status">{reviewPage} / {totalReviewPages}</span>
+                                            <button
+                                                type="button"
+                                                className="page-btn"
+                                                onClick={() => setReviewPage(p => Math.min(totalReviewPages, p + 1))}
+                                                disabled={reviewPage === totalReviewPages}
+                                            >
+                                                다음
+                                            </button>
+                                        </div>
+                                    )}
+                                </>
                             ) : (
                                 <p>아직 작성된 리뷰가 없습니다.</p>
                             )}

--- a/src/pages/InfoMap/c.jsx
+++ b/src/pages/InfoMap/c.jsx
@@ -1,39 +1,368 @@
-import React, { useState } from 'react';
+import React, { useEffect, useMemo, useRef, useState } from 'react';
 import '../../styles/InfoMap/cc.css';
 import TopBanner from '../../components/TopBanner';
 
-function InfoMap() {
+const API_BASE = import.meta.env.VITE_API_BASE;
+const SCHOOL_CENTER = { lat: 37.4868, lng: 126.8015 }; // 가톨릭대학교(부천)
+
+// ---------- 유틸 ----------
+const CATEGORY_COLORS = {
+  전체: '#47609F', // 서브컬러
+  음식: '#0C2E86', // 메인컬러
+  카페: '#788BBC',
+  생활: '#F59E0B',
+  문화: '#10B981',
+};
+
+function svgPin(color = '#47609F') {
+  const svg = `<svg width="28" height="40" viewBox="0 0 28 40" xmlns="http://www.w3.org/2000/svg">
+      <defs><filter id="s" x="-20%" y="-20%" width="140%" height="140%">
+        <feDropShadow dx="0" dy="1" stdDeviation="1" flood-opacity="0.25"/>
+      </filter></defs>
+      <g filter="url(#s)">
+        <path d="M14 38c6.8-10.1 12-14.8 12-22C26 7.8 20.2 2 14 2S2 7.8 2 16c0 7.2 5.2 11.9 12 22z" fill="${color}"/>
+        <circle cx="14" cy="16" r="6" fill="#fff"/>
+      </g>
+    </svg>`;
+  return `data:image/svg+xml;charset=UTF-8,${encodeURIComponent(svg)}`;
+}
+
+// 숫자/날짜 파싱 보조
+const toNumber = (v) => (typeof v === 'number' ? v : Number(v));
+const toDate = (v) => (v ? new Date(v) : null);
+
+// 공용 정규화(각 엔드포인트 스키마 혼합 대응)
+function normalizeItem(d) {
+  // 위경도: 숫자 or 문자열 모두 허용
+  const latRaw = d.lat ?? d.latitude;
+  const lngRaw = d.lng ?? d.longitude;
+  const lat = Number(latRaw);
+  const lng = Number(lngRaw);
+  if (!Number.isFinite(lat) || !Number.isFinite(lng)) return null;
+
+  // id 우선순위: storeId > id > _id > 좌표
+  const id = d.storeId ?? d.id ?? d._id ?? `${lat},${lng}`;
+
+  return {
+    id,
+    storeId: d.storeId ?? d.id ?? d._id ?? id,
+    name: d.name ?? d.title ?? '매장',
+    lat,
+    lng,
+    address: d.address ?? d.roadAddress ?? d.addr ?? '',
+    placeUrl: d.placeUrl ?? d.url ?? '',
+    category: d.category ?? d.type ?? '기타',
+    discount: d.discount ?? d.benefit ?? d.partnershipBenefit ?? '',
+    deadline: d.deadline ?? d.expireAt ?? d.partnershipDeadline ?? '',
+    popularity:
+      typeof d.popularity === 'number'
+        ? d.popularity
+        : toNumber(d.viewCount) || undefined,
+    rating:
+      typeof d.rating === 'number'
+        ? d.rating
+        : toNumber(d.avgRating) || undefined,
+    reviewCount:
+      typeof d.reviewCount === 'number'
+        ? d.reviewCount
+        : toNumber(d.reviews) || undefined,
+    // 원본 전체 보관(디버그/확장용)
+    _raw: d,
+  };
+}
+
+// 클라이언트 폴백 정렬
+function sortClient(items, key) {
+  const arr = [...items];
+  const num = (v) => (typeof v === 'number' ? v : Number(v) || 0);
+  const getDiscPct = (s) => {
+    // "10%" 또는 "₩1000" 형태 모두 대비
+    if (!s || typeof s !== 'string') return 0;
+    const pct = s.match(/(\d+(?:\.\d+)?)\s*%/);
+    if (pct) return Number(pct[1]);
+    const won = s.replace(/[^\d.]/g, '');
+    return Number(won) / 1000; // 대략치
+  };
+  const getDeadline = (d) => toDate(d)?.getTime() || Number.MAX_SAFE_INTEGER;
+
+  switch (key) {
+    case 'popular':
+      return arr.sort((a, b) => num(b.popularity) - num(a.popularity));
+    case 'discountDesc':
+      return arr.sort(
+        (a, b) => getDiscPct(b.discount) - getDiscPct(a.discount)
+      );
+    case 'discountAsc':
+      return arr.sort(
+        (a, b) => getDiscPct(a.discount) - getDiscPct(b.discount)
+      );
+    case 'deadlineAsc':
+      return arr.sort(
+        (a, b) => getDeadline(a.deadline) - getDeadline(b.deadline)
+      );
+    case 'deadlineDesc':
+      return arr.sort(
+        (a, b) => getDeadline(b.deadline) - getDeadline(a.deadline)
+      );
+    case 'idAsc':
+    default:
+      return arr.sort((a, b) => String(a.id).localeCompare(String(b.id)));
+  }
+}
+
+// ---------- 메인 컴포넌트 ----------
+export default function InfoMap() {
   const [category, setCategory] = useState('전체');
   const [sort, setSort] = useState('idAsc');
+  const [keyword, setKeyword] = useState('');
 
-  // 데모 마커 데이터 (좌표 %)
-  const markers = [
-    { id: 1, name: '문과관카페', x: 62, y: 36, color: 'amber' },
-    { id: 2, name: '연남디저트', x: 34, y: 58, color: 'sky' },
-  ];
+  const [items, setItems] = useState([]);
+  const [loading, setLoading] = useState(false);
+  const [err, setErr] = useState('');
+
+  // 지도 refs
+  const mapEl = useRef(null);
+  const mapRef = useRef(null);
+  const clustererRef = useRef(null);
+
+  // 지도 초기화
+  useEffect(() => {
+    let retryId;
+    function init() {
+      const { kakao } = window;
+      if (!kakao || !kakao.maps) {
+        retryId = setTimeout(init, 120);
+        return;
+      }
+      const onReady = () => {
+        if (!mapEl.current) return;
+        const map = new kakao.maps.Map(mapEl.current, {
+          center: new kakao.maps.LatLng(SCHOOL_CENTER.lat, SCHOOL_CENTER.lng),
+          level: 4,
+        });
+        mapRef.current = map;
+        clustererRef.current = new kakao.maps.MarkerClusterer({
+          map,
+          averageCenter: true,
+          minLevel: 7,
+        });
+      };
+      if (typeof kakao.maps.load === 'function') kakao.maps.load(onReady);
+      else onReady();
+    }
+    init();
+    return () => retryId && clearTimeout(retryId);
+  }, []);
+
+  // 키워드 디바운스
+  const [debouncedQ, setDebouncedQ] = useState('');
+  useEffect(() => {
+    const t = setTimeout(() => setDebouncedQ(keyword.trim()), 400);
+    return () => clearTimeout(t);
+  }, [keyword]);
+
+  // 데이터 로드: 단일 or 분리 스키마 모두 대응
+  useEffect(() => {
+    if (!API_BASE) {
+      setErr('VITE_API_BASE 환경변수가 비었습니다.');
+      return;
+    }
+    const ac = new AbortController();
+    (async () => {
+      setLoading(true);
+      setErr('');
+      try {
+        // 1) 단일 엔드포인트 우선 시도
+        const qs1 = new URLSearchParams();
+        if (category && category !== '전체') qs1.set('category', category);
+        if (sort) qs1.set('sort', sort);
+        if (debouncedQ) qs1.set('q', debouncedQ);
+        const url1 = `${API_BASE}/partnership-map${
+          qs1.toString() ? `?${qs1}` : ''
+        }`;
+
+        const try1 = await fetch(url1, {
+          headers: { Accept: 'application/json' },
+          signal: ac.signal,
+        });
+        if (try1.ok) {
+          const data = await try1.json();
+          const normalized = (Array.isArray(data) ? data : [])
+            .map(normalizeItem)
+            .filter(Boolean);
+          setItems(normalized);
+          return;
+        }
+
+        // 2) 분리 엔드포인트 폴백(stores/partnerships/reviews)
+        const qs2 = new URLSearchParams();
+        if (category && category !== '전체') qs2.set('category', category);
+        if (debouncedQ) qs2.set('q', debouncedQ);
+
+        const [storesRes, partsRes, reviewsRes] = await Promise.all([
+          fetch(`${API_BASE}/stores${qs2.toString() ? `?${qs2}` : ''}`, {
+            headers: { Accept: 'application/json' },
+            signal: ac.signal,
+          }),
+          fetch(`${API_BASE}/partnerships${qs2.toString() ? `?${qs2}` : ''}`, {
+            headers: { Accept: 'application/json' },
+            signal: ac.signal,
+          }),
+          fetch(
+            `${API_BASE}/reviews/summary${qs2.toString() ? `?${qs2}` : ''}`,
+            { headers: { Accept: 'application/json' }, signal: ac.signal }
+          ).catch(() => null),
+        ]);
+
+        if (!storesRes.ok) {
+          const tt = await storesRes.text().catch(() => '');
+          throw new Error(`/stores 실패: ${storesRes.status} ${tt}`);
+        }
+
+        const stores = (await storesRes.json()) ?? [];
+        const parts = partsRes?.ok ? await partsRes.json() : [];
+        const revs = reviewsRes && reviewsRes.ok ? await reviewsRes.json() : [];
+
+        // 인덱스화
+        const partByStore = new Map(
+          (Array.isArray(parts) ? parts : []).map((p) => [
+            p.storeId ?? p.id ?? p._id,
+            p,
+          ])
+        );
+        const reviewByStore = new Map(
+          (Array.isArray(revs) ? revs : []).map((r) => [
+            r.storeId ?? r.id ?? r._id,
+            r,
+          ])
+        );
+
+        // 병합 -> 정규화
+        const merged = (Array.isArray(stores) ? stores : [])
+          .map((s) => {
+            const p = partByStore.get(s.id ?? s._id) || {};
+            const r = reviewByStore.get(s.id ?? s._id) || {};
+            return normalizeItem({
+              ...s,
+              storeId: s.id ?? s._id,
+              partnershipBenefit: p.benefit ?? p.discount,
+              partnershipDeadline: p.deadline ?? p.expireAt,
+              viewCount: s.viewCount ?? p.popularity,
+              avgRating: r.avgRating,
+              reviews: r.count,
+            });
+          })
+          .filter(Boolean);
+
+        // 정렬 폴백
+        setItems(sortClient(merged, sort));
+      } catch (e) {
+        // 요청이 취소된 경우(AbortError)는 무시
+        if (e.name === 'AbortError' || String(e.message).includes('aborted')) {
+          return;
+        }
+        setErr(e.message || '데이터 로드 실패');
+        setItems([]);
+      } finally {
+        if (!ac.signal.aborted) {
+          setLoading(false);
+        }
+      }
+    })();
+    return () => ac.abort();
+  }, [category, sort, debouncedQ]);
+
+  // 마커 렌더링
+  useEffect(() => {
+    const { kakao } = window;
+    const map = mapRef.current;
+    const clusterer = clustererRef.current;
+    if (!kakao || !map || !clusterer) return;
+
+    clusterer.clear();
+
+    const col = CATEGORY_COLORS[category] || '#47609F';
+    const markerImage = new kakao.maps.MarkerImage(
+      svgPin(col),
+      new kakao.maps.Size(28, 40),
+      {
+        offset: new kakao.maps.Point(14, 40),
+      }
+    );
+
+    const markers = items.map((m) => {
+      const marker = new kakao.maps.Marker({
+        position: new kakao.maps.LatLng(m.lat, m.lng),
+        image: markerImage,
+        title: m.name,
+      });
+      kakao.maps.event.addListener(marker, 'click', () => {
+        const html = `
+          <div style="padding:8px 10px;max-width:260px;line-height:1.4">
+            <strong style="display:block;margin-bottom:4px">${
+              m.name ?? '매장'
+            }</strong>
+            ${m.address ? `<div>${m.address}</div>` : ''}
+            ${
+              m.discount
+                ? `<div style="margin-top:4px">혜택: ${m.discount}</div>`
+                : ''
+            }
+            ${m.deadline ? `<div>기한: ${m.deadline}</div>` : ''}
+            ${
+              m.rating
+                ? `<div>평점: ${m.rating}${
+                    m.reviewCount ? ` (${m.reviewCount})` : ''
+                  }</div>`
+                : ''
+            }
+            ${
+              m.placeUrl
+                ? `<div style="margin-top:6px"><a href="${m.placeUrl}" target="_blank" rel="noreferrer">상세보기</a></div>`
+                : ''
+            }
+          </div>`;
+        new kakao.maps.InfoWindow({ content: html }).open(map, marker);
+      });
+      return marker;
+    });
+
+    clusterer.addMarkers(markers);
+
+    if (items.length > 0) {
+      const bounds = new kakao.maps.LatLngBounds();
+      items.forEach((m) => bounds.extend(new kakao.maps.LatLng(m.lat, m.lng)));
+      map.setBounds(bounds);
+    } else {
+      map.setCenter(
+        new kakao.maps.LatLng(SCHOOL_CENTER.lat, SCHOOL_CENTER.lng)
+      );
+      map.setLevel(4);
+    }
+  }, [items, category]);
+
+  // 결과 요약
+  const resultText = useMemo(() => {
+    if (loading) return '불러오는 중…';
+    if (err) return `오류: ${err}`;
+    return `결과 ${items.length}개`;
+  }, [loading, err, items.length]);
 
   return (
     <div className="app">
       <div className="app__container">
-        {/* 다른 페이지와 동일한 TopBanner 사용 */}
         <TopBanner activeTab="제휴 지도" />
-
         <main>
-          {/* 페이지 타이틀 섹션 (App.css 토큰 사용) */}
           <section className="section">
-            {/* 화면에는 숨기되 구조 유지 */}
             <h1 className="mappage__title sr-only">가대제휴</h1>
             <p className="mappage__sub">
-              학교 주변 제휴 매장을 지도로 확인하세요.
+              가톨릭대학교 주변 제휴 매장을 지도로 확인하세요.
             </p>
           </section>
 
-          {/* 지도 카드 섹션 */}
           <section className="section">
             <div className="section__head section__head--controls">
               <h2 className="section__title">제휴 지도</h2>
-
-              {/* 셀렉트는 App.css의 공통 스타일을 그대로 사용 */}
               <div className="controls">
                 <select
                   value={category}
@@ -59,31 +388,52 @@ function InfoMap() {
                   <option value="deadlineAsc">기한 빠른 순</option>
                   <option value="deadlineDesc">기한 느린 순</option>
                 </select>
+
+                <input
+                  value={keyword}
+                  onChange={(e) => setKeyword(e.target.value)}
+                  placeholder="키워드(예: 파스타, 치킨)"
+                  style={{
+                    padding: '8px 10px',
+                    border: '1px solid #d0d4da',
+                    borderRadius: 8,
+                  }}
+                />
               </div>
             </div>
 
-            {/* 지도 영역 */}
             <div className="mapcard">
-              <div className="mapcard__inner">
-                {markers.map((m) => (
-                  <button
-                    key={m.id}
-                    className={`pin pin--${m.color}`}
-                    style={{ left: `${m.x}%`, top: `${m.y}%` }}
-                    title={m.name}
-                    aria-label={m.name}
-                    onClick={() => alert(m.name)}
-                  >
-                    <span className="pin__dot" />
-                  </button>
-                ))}
-              </div>
+              <div
+                ref={mapEl}
+                className="mapcard__inner"
+                style={{ height: '420px' }}
+              />
             </div>
+
+            <div style={{ marginTop: 10 }}>
+              <span
+                style={{ color: err ? '#c00' : '#47609F', fontWeight: 700 }}
+              >
+                {resultText}
+              </span>
+            </div>
+
+            {!loading && !err && items.length > 0 && (
+              <ul style={{ marginTop: 12 }}>
+                {items.map((m) => (
+                  <li
+                    key={m.id}
+                    style={{ padding: '8px 0', borderBottom: '1px solid #eee' }}
+                  >
+                    <strong>{m.name}</strong>{' '}
+                    {m.address ? `— ${m.address}` : ''}
+                  </li>
+                ))}
+              </ul>
+            )}
           </section>
         </main>
       </div>
     </div>
   );
 }
-
-export default InfoMap;

--- a/src/pages/ReviewWrite/ReviewModal.jsx
+++ b/src/pages/ReviewWrite/ReviewModal.jsx
@@ -2,6 +2,9 @@ import React, { useEffect, useRef, useState } from "react";
 import ReactDOM from "react-dom";
 import "../../styles/ReviewWrite/ReviewModal.css";
 
+// ✅ .env에 선언된 VITE_API_BASE 사용
+const API_BASE = import.meta.env.VITE_API_BASE;
+
 export default function ReviewModal({ onClose, partnershipId }) {
   const modalRef = useRef(null);
   const firstFocusableRef = useRef(null);
@@ -128,7 +131,9 @@ export default function ReviewModal({ onClose, partnershipId }) {
         fd.append("photoFiles", r.file); // 리뷰 사진 N장
       });
 
-      const postUrl = `/partnership-info/detail/${encodeURIComponent(partnershipId)}/review/post`;
+      // ✅ API_BASE 붙여서 절대 URL 생성
+      const postPath = `/partnership-info/detail/${encodeURIComponent(partnershipId)}/review/post`;
+      const postUrl = `${API_BASE}${postPath}`;
       console.log("[ReviewModal] SUBMIT - POST URL =", postUrl);
 
       const res = await fetch(postUrl, {

--- a/src/pages/ReviewWrite/ReviewModal.jsx
+++ b/src/pages/ReviewWrite/ReviewModal.jsx
@@ -2,7 +2,6 @@ import React, { useEffect, useRef, useState } from "react";
 import ReactDOM from "react-dom";
 import "../../styles/ReviewWrite/ReviewModal.css";
 
-// ✅ .env에 선언된 VITE_API_BASE 사용
 const API_BASE = import.meta.env.VITE_API_BASE;
 
 export default function ReviewModal({ onClose, partnershipId }) {
@@ -21,7 +20,6 @@ export default function ReviewModal({ onClose, partnershipId }) {
   const receiptInputRef = useRef(null);
   const reviewInputRefs = useRef([]);
 
-  // ✅ 모달이 열릴 때 부모에서 받은 partnershipId 확인 로그
   useEffect(() => {
     console.log("[ReviewModal] OPEN - partnershipId (from parent) =", partnershipId);
   }, [partnershipId]);
@@ -123,7 +121,6 @@ export default function ReviewModal({ onClose, partnershipId }) {
     try {
       setSubmitting(true);
 
-      // 서버 명세에 맞춘 키 이름: text / receiptFile / photoFiles
       const fd = new FormData();
       fd.append("text", content); // 리뷰 본문
       fd.append("receiptFile", receipt.file); // 영수증 1장 (필수)
@@ -131,7 +128,6 @@ export default function ReviewModal({ onClose, partnershipId }) {
         fd.append("photoFiles", r.file); // 리뷰 사진 N장
       });
 
-      // ✅ API_BASE 붙여서 절대 URL 생성
       const postPath = `/partnership-info/detail/${encodeURIComponent(partnershipId)}/review/post`;
       const postUrl = `${API_BASE}${postPath}`;
       console.log("[ReviewModal] SUBMIT - POST URL =", postUrl);

--- a/src/pages/ShopInfo/f.jsx
+++ b/src/pages/ShopInfo/f.jsx
@@ -1,165 +1,120 @@
-import { useMemo, useState } from 'react';
-import { useNavigate } from 'react-router-dom';
+import { useEffect, useMemo, useState } from 'react';
+import { useNavigate, useSearchParams } from 'react-router-dom';
 import TopBanner from '../../components/TopBanner';
 import '../../styles/ShopInfo/ff.css';
 
-/** 카테고리/정렬 옵션 (제휴 정보 화면 톤과 동일) */
+/** 서버 기본값 */
+const API_BASE = import.meta.env.VITE_API_BASE ?? 'http://3.134.97.96:8080';
+
+/** 화면 옵션 */
 const CATEGORIES = ['전체', '음식', '카페', '생활', '문화'];
 const SORTS = [
   { key: 'nameAsc', label: '가게명 오름차순' },
   { key: 'nameDesc', label: '가게명 내림차순' },
-  { key: 'favDesc', label: '즐겨찾기 우선' },
   { key: 'parkingDesc', label: '주차 가능 우선' },
 ];
 
-/** 데모 데이터 (API 연동 시 동일 필드로 교체) */
+/** 폴백 목업 (isFav는 더는 사용 안 함) */
 const MOCK_SHOPS = [
-  {
-    id: 1,
-    name: '문과관카페',
-    category: '카페',
-    phone: '02-123-4567',
-    email: 'cafe@uni.kr',
-    address: '가대 문과관 1층',
-    hours: '09:00~19:00',
-    parking: false,
-    isFav: true,
-  },
-  {
-    id: 2,
-    name: '홍대이탈리안',
-    category: '음식',
-    phone: '02-223-1234',
-    email: 'italy@food.kr',
-    address: '역곡로 12',
-    hours: '11:00~22:00',
-    parking: true,
-    isFav: false,
-  },
-  {
-    id: 3,
-    name: '성심당',
-    category: '생활',
-    phone: '02-331-0000',
-    email: 'bakery@shop.kr',
-    address: '신관 앞',
-    hours: '08:00~20:00',
-    parking: false,
-    isFav: false,
-  },
-  {
-    id: 4,
-    name: '연남디저트',
-    category: '카페',
-    phone: '02-991-1199',
-    email: 'dessert@cake.kr',
-    address: '정문 골목',
-    hours: '10:00~21:00',
-    parking: false,
-    isFav: true,
-  },
-  {
-    id: 5,
-    name: '미술관',
-    category: '문화',
-    phone: '02-555-2222',
-    email: 'art@museum.kr',
-    address: '후문 맞은편',
-    hours: '10:00~18:00',
-    parking: true,
-    isFav: false,
-  },
-  {
-    id: 6,
-    name: '상도카페',
-    category: '카페',
-    phone: '02-444-7777',
-    email: 'sangdo@cafe.kr',
-    address: '상도동 45',
-    hours: '09:30~20:30',
-    parking: false,
-    isFav: false,
-  },
-  {
-    id: 7,
-    name: '정문분식',
-    category: '음식',
-    phone: '02-888-9999',
-    email: 'bunsik@shop.kr',
-    address: '정문앞',
-    hours: '10:30~21:00',
-    parking: false,
-    isFav: false,
-  },
-  {
-    id: 8,
-    name: '교내문구',
-    category: '생활',
-    phone: '02-321-2221',
-    email: 'stationery@uni.kr',
-    address: '학생회관 1층',
-    hours: '09:00~18:00',
-    parking: false,
-    isFav: true,
-  },
-  {
-    id: 9,
-    name: '영화관',
-    category: '문화',
-    phone: '02-100-2000',
-    email: 'cinema@film.kr',
-    address: '역곡역 3번출구',
-    hours: '12:00~24:00',
-    parking: true,
-    isFav: false,
-  },
-  {
-    id: 10,
-    name: '충무로카페',
-    category: '카페',
-    phone: '02-712-8888',
-    email: 'chung@cafe.kr',
-    address: '충무로 12',
-    hours: '08:30~19:30',
-    parking: false,
-    isFav: false,
-  },
+  { id: 1,  name: '문과관카페',  category: '카페',  phone: '02-123-4567', email: 'cafe@uni.kr',  address: '가대 문과관 1층', hours: '09:00~19:00', parking: false },
+  { id: 2,  name: '홍대이탈리안',  category: '음식',  phone: '02-223-1234', email: 'italy@food.kr', address: '역곡로 12', hours: '11:00~22:00', parking: true },
+  { id: 3,  name: '성심당',      category: '생활', phone: '02-331-0000', email: 'bakery@shop.kr', address: '신관 앞', hours: '08:00~20:00', parking: false },
+  { id: 4,  name: '연남디저트',    category: '카페',  phone: '02-991-1199', email: 'dessert@cake.kr', address: '정문 골목', hours: '10:00~21:00', parking: false },
+  { id: 5,  name: '미술관',      category: '문화', phone: '02-555-2222', email: 'art@museum.kr', address: '후문 맞은편', hours: '10:00~18:00', parking: true },
+  { id: 6,  name: '상도카페',     category: '카페',  phone: '02-444-7777', email: 'sangdo@cafe.kr', address: '상도동 45', hours: '09:30~20:30', parking: false },
+  { id: 7,  name: '정문분식',     category: '음식',  phone: '02-888-9999', email: 'bunsik@shop.kr', address: '정문앞', hours: '10:30~21:00', parking: false },
+  { id: 8,  name: '교내문구',     category: '생활', phone: '02-321-2221', email: 'stationery@uni.kr', address: '학생회관 1층', hours: '09:00~18:00', parking: false },
+  { id: 9,  name: '영화관',      category: '문화', phone: '02-100-2000', email: 'cinema@film.kr', address: '역곡역 3번출구', hours: '12:00~24:00', parking: true },
+  { id: 10, name: '충무로카페',    category: '카페',  phone: '02-712-8888', email: 'chung@cafe.kr', address: '충무로 12', hours: '08:30~19:30', parking: false },
 ];
 
-/** 내부 카드 컴포넌트 */
-function ShopInfoCard({ shop, onToggleFav }) {
+/** 응답 → 공통 스키마로 정규화 (즐겨찾기 제거) */
+function normalizeStore(d, i = 0) {
+  const id = d.id ?? d._id ?? d.storeId ?? d.partnerId ?? i + 1;
+  const name = d.name ?? d.storeName ?? d.partnerName ?? d.title ?? '매장';
+  const category = d.category ?? d.categoryName ?? d.type ?? d.tags?.[0] ?? '기타';
+  const phone = d.phone ?? d.tel ?? d.phoneNumber ?? '';
+  const email = d.email ?? d.contactEmail ?? '';
+  const address = d.address ?? d.addr ?? d.location ?? '';
+  const hours = d.hours ?? d.openingHours ?? d.businessHours ?? '';
+  const parking = Boolean(
+    d.parking ?? d.hasParking ?? (typeof d.parkingYn === 'string' ? d.parkingYn === 'Y' : false)
+  );
+  return { id, name, category, phone, email, address, hours, parking };
+}
+
+/** 목록 API 유틸 */
+async function fetchStores({ category, sort, q, page, size, signal }) {
+  const candidates = [
+    '/api/v1/stores',
+    '/stores',
+    '/api/v1/partnerships',
+    '/partnerships',
+    '/partnership-map',
+  ];
+
+  const qs = new URLSearchParams({
+    category: category === '전체' ? '' : category,
+    sort,
+    q: q ?? '',
+    page: String(page ?? 1),
+    size: String(size ?? 10),
+
+    // 대체 키들(백엔드 케이스 다양성 대응)
+    keyword: q ?? '',
+    pageIndex: String(page ?? 1),
+    pageSize: String(size ?? 10),
+    order: sort,
+  });
+
+  for (const path of candidates) {
+    try {
+      const res = await fetch(`${API_BASE.replace(/\/$/, '')}${path}?${qs}`, {
+        signal,
+        headers: { Accept: 'application/json' },
+      });
+      if (!res.ok) throw new Error(`HTTP ${res.status}`);
+      const json = await res.json();
+
+      const items =
+        json.items ??
+        json.data ??
+        json.content ??
+        json.results ??
+        (Array.isArray(json) ? json : []);
+
+      if (!Array.isArray(items)) continue;
+
+      const list = items.map((d, i) => normalizeStore(d, i));
+      const total = json.total ?? json.totalElements ?? json.count ?? list.length;
+      return { list, total };
+    } catch (e) {
+      // 사용자가 필터/검색/페이지를 바꾸면 이전 요청은 Abort됩니다 → 그대로 상위로 전달
+      if (e?.name === 'AbortError' || String(e?.message).includes('aborted')) {
+        throw e;
+      }
+      // 그 외엔 다음 후보 경로 시도
+    }
+  }
+  throw new Error('No matching endpoint');
+}
+
+/** 카드 (즐겨찾기 버튼 삭제) */
+function ShopInfoCard({ shop }) {
   return (
-    <article
-      className="shop-card"
-      role="article"
-      aria-labelledby={`shop-${shop.id}-title`}
-    >
+    <article className="shop-card" role="article" aria-labelledby={`shop-${shop.id}-title`}>
       <div className="shop-card__head">
         <h3 id={`shop-${shop.id}-title`} className="shop-card__title">
           {shop.name}
         </h3>
-        <button
-          type="button"
-          className={`shop-card__fav ${shop.isFav ? 'is-on' : ''}`}
-          onClick={() => onToggleFav?.(shop.id)}
-          aria-pressed={shop.isFav}
-        >
-          {shop.isFav ? '★ 즐겨찾기됨' : '☆ 즐겨찾기'}
-        </button>
       </div>
-
       <div className="shop-card__body">
         <dl className="shop-meta">
-          <dt>전화번호</dt>
-          <dd>{shop.phone || '-'}</dd>
-          <dt>이메일</dt>
-          <dd>{shop.email || '-'}</dd>
-          <dt>주소</dt>
-          <dd>{shop.address || '-'}</dd>
-          <dt>운영시간</dt>
-          <dd>{shop.hours || '-'}</dd>
-          <dt>주차여부</dt>
-          <dd>{shop.parking ? '가능' : '불가'}</dd>
+          <dt>전화번호</dt><dd>{shop.phone || '-'}</dd>
+          <dt>이메일</dt><dd>{shop.email || '-'}</dd>
+          <dt>주소</dt><dd>{shop.address || '-'}</dd>
+          <dt>운영시간</dt><dd>{shop.hours || '-'}</dd>
+          <dt>주차여부</dt><dd>{shop.parking ? '가능' : '불가'}</dd>
         </dl>
       </div>
     </article>
@@ -168,32 +123,93 @@ function ShopInfoCard({ shop, onToggleFav }) {
 
 export default function ShopInfo() {
   const navigate = useNavigate();
+  const [sp, setSp] = useSearchParams();
 
-  // TopBanner 탭 전환 → 라우팅 매핑
   const changeTab = (tab) => {
     const t = String(tab);
     if (t.includes('제휴') && t.includes('정보')) return navigate('/');
     if (t.includes('지도')) return navigate('/map');
-    // '제휴사 정보' / '가게 정보' 등 → 현재 페이지
     return navigate('/partners');
   };
 
-  const [category, setCategory] = useState('전체');
-  const [sort, setSort] = useState('nameAsc');
-  const [page, setPage] = useState(1);
+  // URL 초기값
+  const [category, setCategory] = useState(sp.get('category') || '전체');
+  const [sort, setSort] = useState(sp.get('sort') || 'nameAsc');
+  const [keyword, setKeyword] = useState(sp.get('q') || '');
+  const [page, setPage] = useState(Number(sp.get('page') || 1));
+
+  // 데이터 상태
   const [data, setData] = useState(MOCK_SHOPS);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState('');
+  const [total, setTotal] = useState(MOCK_SHOPS.length);
 
-  const PAGE_SIZE = 6; // 2열 x 3행
+  const PAGE_SIZE = 6;
 
+  const syncQuery = (next = {}) => {
+    const params = new URLSearchParams(sp);
+    Object.entries(next).forEach(([k, v]) => {
+      if (v === undefined || v === null || v === '') params.delete(k);
+      else params.set(k, String(v));
+    });
+    setSp(params, { replace: true });
+  };
+
+  useEffect(() => {
+    const controller = new AbortController();
+
+    const load = async () => {
+      setLoading(true);
+      setError('');
+      try {
+        const { list, total } = await fetchStores({
+          category,
+          sort,
+          q: keyword.trim(),
+          page,
+          size: PAGE_SIZE,
+          signal: controller.signal,
+        });
+        if (!controller.signal.aborted) {
+          setData(list);
+          setTotal(total);
+        }
+      } catch (e) {
+        // 요청 취소는 정상 동작이므로 에러로 보여주지 않음
+        if (e?.name === 'AbortError' || String(e?.message).includes('aborted')) {
+          return;
+        }
+        setError('서버 데이터를 불러오지 못해 임시 데이터로 표시합니다.');
+        setData(MOCK_SHOPS);
+        setTotal(MOCK_SHOPS.length);
+      } finally {
+        if (!controller.signal.aborted) {
+          setLoading(false);
+        }
+      }
+    };
+
+    load();
+    return () => controller.abort();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [category, sort, keyword, page]);
+
+  // 클라이언트 보정 정렬/필터 (즐겨찾기 제거됨)
   const filtered = useMemo(() => {
-    let list =
-      category === '전체' ? data : data.filter((s) => s.category === category);
+    let list = data;
+    if (category !== '전체') list = list.filter((s) => s.category === category);
+    if (keyword.trim()) {
+      const kw = keyword.trim().toLowerCase();
+      list = list.filter(
+        (s) =>
+          s.name.toLowerCase().includes(kw) ||
+          s.address.toLowerCase().includes(kw) ||
+          (s.category || '').toLowerCase().includes(kw)
+      );
+    }
     switch (sort) {
       case 'nameDesc':
         list = [...list].sort((a, b) => b.name.localeCompare(a.name));
-        break;
-      case 'favDesc':
-        list = [...list].sort((a, b) => Number(b.isFav) - Number(a.isFav));
         break;
       case 'parkingDesc':
         list = [...list].sort((a, b) => Number(b.parking) - Number(a.parking));
@@ -204,9 +220,9 @@ export default function ShopInfo() {
         break;
     }
     return list;
-  }, [category, sort, data]);
+  }, [data, category, sort, keyword]);
 
-  const pageCount = Math.max(1, Math.ceil(filtered.length / PAGE_SIZE));
+  const pageCount = Math.max(1, Math.ceil((total || filtered.length) / PAGE_SIZE));
   const current = useMemo(
     () => filtered.slice((page - 1) * PAGE_SIZE, page * PAGE_SIZE),
     [filtered, page]
@@ -215,74 +231,75 @@ export default function ShopInfo() {
   const changePage = (p) => {
     if (p < 1 || p > pageCount) return;
     setPage(p);
+    syncQuery({ page: p });
     window.scrollTo({ top: 0, behavior: 'smooth' });
-  };
-
-  const toggleFav = (id) => {
-    setData((prev) =>
-      prev.map((s) => (s.id === id ? { ...s, isFav: !s.isFav } : s))
-    );
   };
 
   return (
     <div className="app__container">
-      {/* 상단 내비 (두 번째 화면과 동일한 컴포넌트) */}
       <TopBanner activeTab={'제휴사 정보'} onChange={changeTab} />
-
       <main className="section shop">
         <div className="section__head shop__head">
           <h2 className="section__title shop__title">가게 정보</h2>
 
           <div className="controls">
+            <input
+              value={keyword}
+              onChange={(e) => {
+                setKeyword(e.target.value);
+                setPage(1);
+                syncQuery({ q: e.target.value, page: 1 });
+              }}
+              placeholder="가게/주소/카테고리 검색"
+              aria-label="검색어"
+              className="control__search"
+            />
             <select
               value={category}
               onChange={(e) => {
                 setCategory(e.target.value);
                 setPage(1);
+                syncQuery({ category: e.target.value, page: 1 });
               }}
               aria-label="카테고리"
             >
               {CATEGORIES.map((c) => (
-                <option key={c} value={c}>
-                  {c}
-                </option>
+                <option key={c} value={c}>{c}</option>
               ))}
             </select>
-
             <select
               value={sort}
               onChange={(e) => {
                 setSort(e.target.value);
                 setPage(1);
+                syncQuery({ sort: e.target.value, page: 1 });
               }}
               aria-label="정렬 기준"
             >
               {SORTS.map((s) => (
-                <option key={s.key} value={s.key}>
-                  {s.label}
-                </option>
+                <option key={s.key} value={s.key}>{s.label}</option>
               ))}
             </select>
           </div>
         </div>
 
-        {/* 2열 그리드 */}
+        {loading && <p className="hint">불러오는 중…</p>}
+        {!!error && <p className="hint hint--warn">{error}</p>}
+
         <div className="shop-grid">
           {current.map((shop) => (
-            <ShopInfoCard key={shop.id} shop={shop} onToggleFav={toggleFav} />
+            <ShopInfoCard key={shop.id} shop={shop} />
           ))}
+          {!loading && current.length === 0 && (
+            <p className="hint">조건에 맞는 가게가 없습니다.</p>
+          )}
         </div>
 
-        {/* 페이지네이션 */}
         <nav className="pagination" aria-label="페이지네이션">
-          <button
-            className="pagination__btn"
-            onClick={() => changePage(page - 1)}
-            disabled={page === 1}
-          >
+          <button className="pagination__btn" onClick={() => changePage(page - 1)} disabled={page === 1}>
             이전
           </button>
-          {Array.from({ length: pageCount }, (_, i) => i + 1).map((p) => (
+          {Array.from({ length: Math.max(1, pageCount) }, (_, i) => i + 1).map((p) => (
             <button
               key={p}
               className={`pagination__num ${p === page ? 'is-active' : ''}`}
@@ -291,11 +308,7 @@ export default function ShopInfo() {
               {p}
             </button>
           ))}
-          <button
-            className="pagination__btn"
-            onClick={() => changePage(page + 1)}
-            disabled={page === pageCount}
-          >
+          <button className="pagination__btn" onClick={() => changePage(page + 1)} disabled={page === pageCount}>
             다음
           </button>
         </nav>

--- a/src/styles/InfoDetail/OceanWorld.css
+++ b/src/styles/InfoDetail/OceanWorld.css
@@ -6,6 +6,7 @@
 }
 
 /* 상세 카드 */
+/* 상세 카드 */
 .detail-card {
     background-color: rgb(255, 255, 255);
     border-radius: 12px;
@@ -13,7 +14,8 @@
     max-width: 800px;
     margin: auto;
     box-shadow: 0 4px 8px rgba(0, 0, 0, 0.1);
-    max-height: 700px;
+    /* max-height: 700px;  <-- 제거 */
+    max-height: none;        /* ✅ 높이 제한 해제 (내용만큼 확장) */
 }
 
 .store-name {
@@ -94,3 +96,111 @@
 .review-write-btn:hover {
     background-color: #3a3f96;
 }
+
+/* 리뷰 아이템 카드 */
+.review-item {
+    background-color: #fff;
+    border-radius: 5px;
+    padding: 12px;
+    margin: 12px 0;
+    text-align: left;
+    box-shadow: 0 1px 3px rgba(0,0,0,0.08);
+}
+
+/* 리뷰 사진 묶음 */
+.review-photos {
+    display: flex;
+    gap: 8px;
+    margin-top: 8px;
+    flex-wrap: nowrap;        /* 최대 3장만, 줄바꿈 안 함 */
+    justify-content: flex-start;
+}
+
+/* 리뷰 사진 */
+.review-photo {
+    width: 120px;
+    height: 120px;
+    object-fit: cover;
+    border-radius: 4px;
+    border: 1px solid #e6ecf7;
+    flex-shrink: 0;           /* 줄어들지 않게 고정 */
+}
+
+/* ========== AI 요약 타이틀 + 카드 ========== */
+
+.review-list-title {
+  margin: 20px 0 12px;
+  font-size: 16px;
+  font-weight: bold;
+  color: var(--ink-900, #0E1A2B);
+  text-align: left;
+}
+
+/* 블록 전체 여백 */
+.review-summary-block { 
+  margin: 12px 0 16px; 
+}
+
+/* 위쪽 라벨 줄 (🤖 + AI 요약) */
+.review-summary-head {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  margin-bottom: 8px;
+  font-size: 16px;       /* 👈 리뷰 제목과 동일하게 */
+  font-weight: bold;     /* 굵기 맞춤 */
+  color: var(--ink-700, #23324D);
+}
+
+/* 이모지 크기만 살짝 키움 */
+.review-summary-emoji { 
+  font-size: 18px; 
+  line-height: 1; 
+}
+
+/* 흰색 네모 카드 (본문) */
+.review-summary-card {
+  background: #fff;
+  border-radius: 5px;
+  padding: 16px;
+  box-shadow: 0 1px 3px rgba(0,0,0,0.08);
+  font-size: 14px;
+  line-height: 1.7;
+  color: var(--ink-900, #0E1A2B);
+}
+
+/* 페이지네이션 (추가) */
+.review-pagination {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    gap: 10px;
+    margin: 16px 0 4px;
+}
+
+.page-btn {
+    padding: 6px 12px;
+    border: 1px solid #d9e0f2;
+    background: #fff;
+    border-radius: 6px;
+    font-size: 13px;
+    cursor: pointer;
+    transition: background-color .15s ease, border-color .15s ease;
+}
+
+.page-btn:hover:not(:disabled) {
+    background: #f7f9fe;
+    border-color: #cbd6f3;
+}
+
+.page-btn:disabled {
+    opacity: 0.5;
+    cursor: not-allowed;
+}
+
+.page-status {
+    font-size: 13px;
+    color: var(--ink-700, #23324D);
+}
+
+.review-section { text-align: left; }

--- a/src/styles/InfoDetail/OceanWorld.css
+++ b/src/styles/InfoDetail/OceanWorld.css
@@ -6,7 +6,6 @@
 }
 
 /* 상세 카드 */
-/* 상세 카드 */
 .detail-card {
     background-color: rgb(255, 255, 255);
     border-radius: 12px;
@@ -14,8 +13,7 @@
     max-width: 800px;
     margin: auto;
     box-shadow: 0 4px 8px rgba(0, 0, 0, 0.1);
-    /* max-height: 700px;  <-- 제거 */
-    max-height: none;        /* ✅ 높이 제한 해제 (내용만큼 확장) */
+    max-height: none;
 }
 
 .store-name {
@@ -81,7 +79,8 @@
 }
 
 .review-write-btn {
-    margin-top: 15px;
+    margin: 15px auto;
+    display: block;
     padding: 10px 16px;
     background-color: #4a4fa6;
     color: white;
@@ -97,7 +96,7 @@
     background-color: #3a3f96;
 }
 
-/* 리뷰 아이템 카드 */
+
 .review-item {
     background-color: #fff;
     border-radius: 5px;
@@ -107,26 +106,23 @@
     box-shadow: 0 1px 3px rgba(0,0,0,0.08);
 }
 
-/* 리뷰 사진 묶음 */
+
 .review-photos {
     display: flex;
     gap: 8px;
     margin-top: 8px;
-    flex-wrap: nowrap;        /* 최대 3장만, 줄바꿈 안 함 */
+    flex-wrap: nowrap;
     justify-content: flex-start;
 }
 
-/* 리뷰 사진 */
 .review-photo {
     width: 120px;
     height: 120px;
     object-fit: cover;
     border-radius: 4px;
     border: 1px solid #e6ecf7;
-    flex-shrink: 0;           /* 줄어들지 않게 고정 */
+    flex-shrink: 0;
 }
-
-/* ========== AI 요약 타이틀 + 카드 ========== */
 
 .review-list-title {
   margin: 20px 0 12px;
@@ -136,29 +132,25 @@
   text-align: left;
 }
 
-/* 블록 전체 여백 */
 .review-summary-block { 
   margin: 12px 0 16px; 
 }
 
-/* 위쪽 라벨 줄 (🤖 + AI 요약) */
 .review-summary-head {
   display: flex;
   align-items: center;
   gap: 6px;
   margin-bottom: 8px;
-  font-size: 16px;       /* 👈 리뷰 제목과 동일하게 */
-  font-weight: bold;     /* 굵기 맞춤 */
+  font-size: 16px;
+  font-weight: bold;
   color: var(--ink-700, #23324D);
 }
 
-/* 이모지 크기만 살짝 키움 */
 .review-summary-emoji { 
   font-size: 18px; 
   line-height: 1; 
 }
 
-/* 흰색 네모 카드 (본문) */
 .review-summary-card {
   background: #fff;
   border-radius: 5px;
@@ -169,7 +161,6 @@
   color: var(--ink-900, #0E1A2B);
 }
 
-/* 페이지네이션 (추가) */
 .review-pagination {
     display: flex;
     align-items: center;

--- a/src/styles/ReviewWrite/ReviewModal.css
+++ b/src/styles/ReviewWrite/ReviewModal.css
@@ -1,10 +1,9 @@
-/* 오버레이 */
 .review-modal__overlay{
   position: fixed; inset: 0;
-  background: rgba(14,26,43,0.40); /* ink-900 기반 반투명 */
+  background: rgba(14,26,43,0.40);
   display: flex; align-items: center; justify-content: center;
   padding: 24px;
-  z-index: 1000; /* TopBanner(10)보다 높게 */
+  z-index: 1000;
 }
 
 /* 카드 */
@@ -69,7 +68,6 @@
   opacity: 1;
 }
 
-/* 푸터 버튼 */
 .review-modal__footer{ display: flex; justify-content: center; margin-top: 16px; }
 .btn-brand{
   height: 39px; padding: 0 16px;
@@ -78,14 +76,12 @@
   font-weight: 700; font-size: 17px; cursor: pointer;
 }
 
-/* 접근성 유틸 (이미 App.css에도 있을 수 있음) */
 .sr-only{
   position: absolute; width: 1px; height: 1px; padding: 0; margin: -1px;
   overflow: hidden; clip: rect(0 0 0 0); white-space: nowrap; border: 0;
 }
 
-/* 미리보기 표시 & 액션 버튼 */
-.upload-box.has-image { background: #000; } /* 대비감만 살짝 */
+.upload-box.has-image { background: #000; }
 
 .upload-preview{
   position: absolute; inset: 0;
@@ -96,19 +92,19 @@
 
 .upload-actions{
   position: absolute;
-  bottom: 6px;        /* 세로 위치 그대로 */
-  left: 0;            /* 좌우를 꽉 채운 뒤 */
+  bottom: 6px;
+  left: 0;
   right: 0;
   display: flex;
   gap: 6px;
-  justify-content: center; /* 가로 가운데 정렬 */
+  justify-content: center;
 }
 
 .upload-action{
   border: 0; border-radius: 4px;
   padding: 4px 8px;
   font-size: 12px; font-weight: 600;
-  background: #0C2E86; /* brand-500 기반 */
+  background: #0C2E86;
   color: #fff; cursor: pointer;
 }
 

--- a/vite.config.js
+++ b/vite.config.js
@@ -4,4 +4,13 @@ import react from '@vitejs/plugin-react'
 // https://vite.dev/config/
 export default defineConfig({
   plugins: [react()],
+  server: {
+    proxy: {
+      '/api': {
+        target: 'http://3.134.97.96:8080',
+        changeOrigin: true,
+        rewrite: (path) => path.replace(/^\/api/, ''), 
+      },
+    },
+  },
 })


### PR DESCRIPTION
# OceanWorld.jsx 수정 내역

1. 이미지 경로 처리 함수 추가
   - /files/... 경로를 API_BASE와 합쳐 절대 경로로 만드는 toAbsUrl(path) 함수 추가.

2. 메인 이미지 교체
   - 기존 src="/oceanworld.png" → src={toAbsUrl(reviewData.partnershipImageUrl) || "/oceanworld.png"} 로 변경.

3. 리뷰 API 연동
   - /review API 호출 추가.
   - 상태 구조를 { partnershipImageUrl, summary, items[] } 형태로 정리.

4. 리뷰 요약 표시 추가
   - 리뷰 탭 상단에 🤖 AI 요약 블록 추가.
   - 요약이 없으면 "리뷰 요약이 없습니다." 표시.

5. 리뷰 리스트 렌더링 개선
   - 리뷰별 text, photoUrl[] 출력.
   - 여러 장일 경우 썸네일(.review-photo)로 렌더링.

6. 리뷰 작성 버튼 추가 및 중앙 정렬
   - 리뷰 탭에 "리뷰 작성" 버튼 추가.
   - CSS로 가운데 정렬(margin: auto; display: block;).

7. 리뷰 제목 + 개수 표시
   - "리뷰 (n)" 형식으로 제목 표시하도록 review-list-title 추가.

8. 페이지네이션 기능 추가
   - 상태: reviewPage, REVIEWS_PER_PAGE = 7.
   - pagedReviews만 렌더링.
   - "이전 / 현재페이지 / 다음" 버튼으로 페이지 이동 가능.


# OceanWorld.css 수정 내역

1. 상세 카드 높이 제한 해제
   - .detail-card의 max-height: 700px; 제거 → max-height: none;.

2. 리뷰 카드화
   - .review-item에 흰 배경, 둥근 모서리, 그림자 적용.

3. 리뷰 사진 썸네일 스타일
   - .review-photo 크기 120×120px, object-fit: cover.
   - 가로로 최대 3장까지 자연스럽게 나열.

4. AI 요약 카드 스타일링
   - .review-summary-block, .review-summary-head, .review-summary-card 추가.
   - 🤖 아이콘 + “AI 요약” 라벨 표시, 본문은 흰색 카드 안에 출력.

5. 리뷰 제목 스타일링
   - .review-list-title를 "리뷰 (n)" 표시용으로 추가.
   - AI 요약 라벨과 동일한 크기/굵기 (16px bold)로 통일.

6. 리뷰 작성 버튼 중앙 정렬
   - .review-write-btn → margin: auto; display: block;.

7. 페이지네이션 CSS 추가
   - .review-pagination, .page-btn, .page-status 추가.
   - 버튼 hover/disabled 스타일링, 페이지 상태 중앙 표시.